### PR TITLE
comments in code and EMG constrained example

### DIFF
--- a/Examples/Example_trackUS/Example_MRS.m
+++ b/Examples/Example_trackUS/Example_MRS.m
@@ -16,7 +16,7 @@ model_path  = fullfile(DataPath,'model.osim');
 Out_path    = fullfile(ExamplePath,'Results');                    % folder to store results
 
 % Get start and end time of the different files
-time = [0 9999];  % (select all time frames between 0 and 9999) 
+time = [0 9999; 0 9999; 0 9999];  % select all time frames between 0 and 9999 for the three trials
 
 % degrees of freedom
 Misc.DofNames_Input={'ankle_angle_l','knee_angle_l','hip_flexion_l','hip_adduction_l','hip_rotation_l'};    % select the DOFs you want to include in the optimization

--- a/Examples/Example_trackUS/Example_US_Tracking.m
+++ b/Examples/Example_trackUS/Example_US_Tracking.m
@@ -11,7 +11,7 @@ DataPath = [pwd '\Data'];
 % As example we use trial 1 2 & 4 
 Misc.IKfile = {fullfile(DataPath,'trial_1_IK.mot'); fullfile(DataPath,'trial_2_IK.mot'); fullfile(DataPath,'trial_4_IK.mot')};
 Misc.IDfile = {fullfile(DataPath,'trial_1_ID.mot'); fullfile(DataPath,'trial_2_ID.mot'); fullfile(DataPath,'trial_4_ID.mot')};
-Misc.USfile = {fullfile(DataPath,'trial_1_US.mot'); fullfile(DataPath,'trial_2_US.mot'); fullfile(DataPath,'trial_4_US.mot')}; %
+Misc.USfile = {fullfile(DataPath,'trial_1_US.mot'); fullfile(DataPath,'trial_2_US.mot'); fullfile(DataPath,'trial_4_US.mot')}; % in mm
 model_path  = fullfile(DataPath,'model.osim');
 Out_path    = fullfile(ExamplePath,'Results');                    % folder to store results
 

--- a/MuscleModel/EMG/GetEMGInfo.m
+++ b/MuscleModel/EMG/GetEMGInfo.m
@@ -72,7 +72,7 @@ if boolEMG
     
     %% Process the data 
     for iF = 1:nF
-        EMGdat              = EMGFile(iF).data;        
+        EMGdat    = EMGFile(iF).data;        
         [nfr, nc] = size(EMGdat);  
         % get the EMG data
         nIn = length(Misc.EMGSelection);

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following input arguments are required to use EMG data:
 
 The following input arguments are required to use ultrasound data:
    - **Misc.UStracking**: boolean to select whether you want to track provided muscle fiber lengths.
-   - **Misc.USfile**: cell array of filenames containing fiber length data of different motion trials (.mot file). The fiber length data is usually measured using ultra-sound (US).
+   - **Misc.USfile**: cell array of filenames containing fiber length data of different motion trials (.mot file). The fiber length data is usually measured using ultra-sound (US) [expects fiber lengths in mm].
    - **Misc.USSelection**: cell array with muscles used in fiber length tracking.
 
 #### Required input arguments for parameter optimization
@@ -351,7 +351,7 @@ See "Info on parameter estimation" to combine EMG information with parameter est
 
 You can use ultrasound information to estimate muscle-tendon properties by tracking fiber lengths in the muscle redundancy problem. We provided an example in the folder "Example_UStracking" based on Delabastita et al. 2020 (https://link.springer.com/article/10.1007/s10439-019-02395-x).
 
-You can input ultrasound data by selecting the right motion file. This file should contain fiber length (in m). Note muscle names in the header of this file should be the same as in the OpenSim model.
+You can input ultrasound data by selecting the right motion file. This file should contain fiber length (in mm). Note muscle names in the header of this file should be the same as in the OpenSim model.
 
 ```matlab
 Misc.USfile = {fullfile(DataPath,'PSF_US_stride2.mot');fullfile(DataPath,'+8_US_stride2.mot');fullfile(DataPath,'+15_US_stride2.mot')};

--- a/solveMuscleRedundancy.m
+++ b/solveMuscleRedundancy.m
@@ -493,7 +493,6 @@ if BoolParamOpt == 1
     if ~isempty(Misc.USfile)
         for trial = 1:Misc.nTrials
             DatStore(trial).boolUS = 1;
-            USTracking(trial).data = interp1(DatStore(trial).US.time,DatStore(trial).US.USsel,Mesh(trial).t(1:end));
             DatStore(trial).USTracking = interp1(DatStore(trial).US.time,DatStore(trial).US.USsel,Mesh(trial).t(1:end));
         end
     end

--- a/solveMuscleRedundancy.m
+++ b/solveMuscleRedundancy.m
@@ -17,12 +17,12 @@ function [Results,DatStore,Misc] = solveMuscleRedundancy(model_path,time,OutPath
 Misc = DefaultSettings(Misc);
 
 % number of motion trials
-Misc.nTrials = size(Misc.IKfile,1);
+Misc.nTrials = length(Misc.IKfile);
 
 %check if we have to adapt the start and end time so that it corresponds to
 %time frames in the IK solution
 [time] = Check_TimeIndices(Misc,time);
-
+Misc.time=time;
 
 %% Extract muscle information
 % ----------------------------------------------------------------------- %
@@ -32,8 +32,7 @@ for i = 1:Misc.nTrials
     % select the IK and ID file
     IK_path_trial = Misc.IKfile{i};
     ID_path_trial = Misc.IDfile{i};
-    % Run muscle analysis
-    Misc.time=time;
+    % Run muscle analysis    
     MuscleAnalysisPath=fullfile(OutPath,'MuscleAnalysis'); if ~exist(MuscleAnalysisPath,'dir'); mkdir(MuscleAnalysisPath); end
     if Misc.RunAnalysis
         disp('MuscleAnalysis Running .....');
@@ -418,7 +417,7 @@ if BoolParamOpt == 1
     end
     opti_MTE.subject_to(lb_lTs_scaling < lTs_scaling_param < ub_lTs_scaling);
     
-    % Free tendon stifness
+    % Free tendon stiffness
     kT_scaling_param = opti_MTE.variable(NMuscles,1);
     lb_kT_scaling_param = ones(NMuscles,1); 
     ub_kT_scaling_param = ones(NMuscles,1);
@@ -494,7 +493,6 @@ if BoolParamOpt == 1
     if ~isempty(Misc.USfile)
         for trial = 1:Misc.nTrials
             DatStore(trial).boolUS = 1;
-            USdata =  importdata(Misc.USfile{trial});
             USTracking(trial).data = interp1(DatStore(trial).US.time,DatStore(trial).US.USsel,Mesh(trial).t(1:end));
             DatStore(trial).USTracking = interp1(DatStore(trial).US.time,DatStore(trial).US.USsel,Mesh(trial).t(1:end));
         end
@@ -544,8 +542,8 @@ if BoolParamOpt == 1
         % tracking lMtilde
         if DatStore(trial).US.boolUS
             lMo = lMo_scaling_param(DatStore(trial).USsel)'.*Misc.params(2,DatStore(trial).USsel(:));
-            lMo = ones(size(USTracking(trial).data,1),1)*lMo;
-            lMtilde_tracking = USTracking(trial).data./lMo/1000; % US data expected in mm in the input file.
+            lMo = ones(size(DatStore(trial).USTracking,1),1)*lMo;
+            lMtilde_tracking = DatStore(trial).USTracking./lMo/1000; % US data expected in mm in the input file.
             lMtilde_simulated = lMtilde(DatStore(trial).US.USindices,(N_acc+trial:N_acc+trial+N));
             if size(lMtilde_simulated,1) ~= size(lMtilde_tracking,1)
                 lMtilde_simulated = lMtilde_simulated';

--- a/solveMuscleRedundancy.m
+++ b/solveMuscleRedundancy.m
@@ -866,9 +866,10 @@ if Misc.ValidationBool == true && BoolParamOpt
     end
     clear opti_validation a lMtilde e vMtilde aT
 end
+% add selected muscle names to the output structure
+Results.MuscleNames = DatStore.MuscleNames;
 
 %% Plot Output
-
 % plot EMG tracking
 if Misc.PlotBool && Misc.EMGconstr == 1
     h = PlotEMGTracking(Results,DatStore);


### PR DESCRIPTION
This PR handles:
1) EMG constrained example added
2) small error in time vector in US tracking example (only MRS)
3) adapted README: ultrasound data is in mm instead of m
4) number of trials is computed as length of Misc.IKfile cell array instead of number of rows (needed in case input is provided as columns, this was the case in one of our examples)