### PR TITLE
Very minor updates for runtime

### DIFF
--- a/IO_Functions/DefaultSettings.m
+++ b/IO_Functions/DefaultSettings.m
@@ -122,7 +122,12 @@ if ~isfield(Misc,'EMGSelection')
     Misc.EMGSelection = [];
 end
 
-%% Info related to parameter optimizatiEMGbounds on
+%% Info related to parameter optimization
+
+if ~isfield(Misc, 'BoolParamOpt')
+    Misc.BoolParamOpt = 0;
+end
+
 if isfield(Misc,'Estimate_OptimalFiberLength')
     [r c] = size(Misc.Estimate_OptimalFiberLength);
     if ((r == 1) && (c > 1))

--- a/MuscleModel/ReadFromModel/getMuscleInfo.m
+++ b/MuscleModel/ReadFromModel/getMuscleInfo.m
@@ -126,7 +126,6 @@ for t = 1:Misc.nTrials
     ID_Header_inds=zeros(size(DOF_inds));  IK_Header_inds = zeros(size(DOF_inds));
     for i=1:length(Misc.DofNames{t})
        ID_Header_inds(i)=find(strcmp([Misc.DofNames{t}{i} '_moment'],ID_header));
-       %ID_Header_inds(i)=find(strcmp(Misc.DofNames{t}{i},ID_header));
        IK_Header_inds(i)=find(strcmp(Misc.DofNames{t}{i},IK_header)); 
     end
 

--- a/MuscleModel/ReadFromModel/getMuscleInfo.m
+++ b/MuscleModel/ReadFromModel/getMuscleInfo.m
@@ -126,6 +126,7 @@ for t = 1:Misc.nTrials
     ID_Header_inds=zeros(size(DOF_inds));  IK_Header_inds = zeros(size(DOF_inds));
     for i=1:length(Misc.DofNames{t})
        ID_Header_inds(i)=find(strcmp([Misc.DofNames{t}{i} '_moment'],ID_header));
+       %ID_Header_inds(i)=find(strcmp(Misc.DofNames{t}{i},ID_header));
        IK_Header_inds(i)=find(strcmp(Misc.DofNames{t}{i},IK_header)); 
     end
 

--- a/solveMuscleRedundancy.m
+++ b/solveMuscleRedundancy.m
@@ -82,6 +82,10 @@ for i=1:Misc.nTrials
     DatStore = SolveStaticOptimization_IPOPT_CasADi(DatStore,Misc,i);
 end
 
+% save states and variables from static optimisation, this will be
+% overwritten later with dynamic optimisation results
+save(fullfile(Misc.OutPath,[Misc.AnalysisID '_Results.mat']),'DatStore','Misc');
+
 %% Descretisation
 %------------------------------------------------------------------------ %
 % mesh descretisation
@@ -182,8 +186,14 @@ if Misc.MRSBool == 1
         MuscProperties.kT = Misc.kT';
         MuscProperties.shift = Misc.shift';
         % formulate and solve the optimal control problem
-        [Results] = FormulateAndSolveMRS(Misc,DatStore,Mesh,trial,SolverSetup,Results,...
-            NMuscles,IG,MuscProperties,'genericMRS');
+        %try
+            [Results] = FormulateAndSolveMRS(Misc,DatStore,Mesh,trial,SolverSetup,Results,...
+                NMuscles,IG,MuscProperties,'genericMRS');
+        %catch excp_genericMRS
+        %    fprintf(2, "\nERROR: Generic MRS failed.\n");
+        %    fprintf(2, "%s\n", excp_genericMRS.message)
+        %end
+
     end
 end
 
@@ -214,7 +224,7 @@ end
 
 % Parameter optimization selected if EMG information or ultrasound
 % information is active
-BoolParamOpt = true;
+BoolParamOpt = false;
 % if Misc.UStracking == 1 || Misc.EMGconstr == 1
 %     BoolParamOpt = 1;
 % end
@@ -338,15 +348,21 @@ end
 
 % plot the states of the muscles in the simulation
 if Misc.PlotBool
-    h = PlotStates(Results,DatStore,Misc);
-    if ~isdir(fullfile(Misc.OutPath,'figures'))
-        mkdir(fullfile(Misc.OutPath,'figures'));
-    end
-    saveas(h,fullfile(Misc.OutPath,'figures','fig_States.fig'));
+    %try
+        h = PlotStates(Results,DatStore,Misc);
+        if ~isdir(fullfile(Misc.OutPath,'figures'))
+            mkdir(fullfile(Misc.OutPath,'figures'));
+        end
+        saveas(h,fullfile(Misc.OutPath,'figures','fig_States.fig'));
+    %catch excp_plot
+    %    fprintf(2, "\nERROR: Plot states failed.\n");
+    %    fprintf(2, "%s\n", excp_plot.message)
+    %end
 end
 
 %% save the results
-% plot states and variables from parameter estimation simulation
+% save states and variables from parameter estimation simulation,
+% overwrites earlier save for static optimisation
 save(fullfile(Misc.OutPath,[Misc.AnalysisID '_Results.mat']),'Results','DatStore','Misc');
 
 % write estimated parameters to new duplicate osim model

--- a/solveMuscleRedundancy.m
+++ b/solveMuscleRedundancy.m
@@ -224,11 +224,11 @@ end
 
 % Parameter optimization selected if EMG information or ultrasound
 % information is active
-BoolParamOpt = false;
+% BoolParamOpt = true;
 % if Misc.UStracking == 1 || Misc.EMGconstr == 1
 %     BoolParamOpt = 1;
 % end
-if BoolParamOpt == 1
+if Misc.BoolParamOpt == 1
     if length(Misc.opt_sides)>1
         for s=1:length(Misc.opt_sides)
             Misc.sideOpt = Misc.opt_sides{s};
@@ -266,7 +266,7 @@ Results.Param.Original.lTs   = Misc.params(3,:);
 Results.Param.Original.alphao = Misc.params(4,:);
 Results.Param.Original.kT   = Misc.kT;
 % save estimated parameters
-if BoolParamOpt
+if Misc.BoolParamOpt
     Results.Param.Estimated.FMo    = Results.Param.Original.FMo;
     Results.Param.Estimated.lMo    = Results.Param.Original.lMo .* Results.Param.lMo_scaling_paramopt';
     Results.Param.Estimated.lTs    = Results.Param.Original.lTs .* Results.Param.lTs_scaling_paramopt';
@@ -287,7 +287,7 @@ end
 
 %% Run the MRS problem with estimated paramters (without EMG or US data)
 
-if Misc.ValidationBool == true && BoolParamOpt
+if Misc.ValidationBool == true && Misc.BoolParamOpt
     for trial = 1:Misc.nTrials
         clear IG
         IG.a = Results.MActivation(trial).MTE;
@@ -325,7 +325,7 @@ if Misc.PlotBool && Misc.EMGconstr == 1
 end
 
 % plot estimated parameters
-if Misc.PlotBool == 1 && BoolParamOpt ==1
+if Misc.PlotBool == 1 && Misc.BoolParamOpt ==1
     if length(Misc.opt_sides)>1
         h = PlotEstimatedParameters(Results,Misc);
     else
@@ -366,7 +366,7 @@ end
 save(fullfile(Misc.OutPath,[Misc.AnalysisID '_Results.mat']),'Results','DatStore','Misc');
 
 % write estimated parameters to new duplicate osim model
-if BoolParamOpt
+if Misc.BoolParamOpt
     muscleParams = Results.Param.Estimated;
     muscleNames  = Misc.allMuscleList;
     modelPath    = char(Misc.model_path);

--- a/solveMuscleRedundancy.m
+++ b/solveMuscleRedundancy.m
@@ -1,4 +1,4 @@
-    function [Results,DatStore,Misc] = solveMuscleRedundancy(time,Misc)
+function [Results,DatStore,Misc] = solveMuscleRedundancy(time,Misc)
 % -----------------------------------------------------------------------%
 % INPUTS:
 %           time: time window

--- a/solveMuscleRedundancy.m
+++ b/solveMuscleRedundancy.m
@@ -1,4 +1,4 @@
-function [Results,DatStore,Misc] = solveMuscleRedundancy(time,Misc)
+    function [Results,DatStore,Misc] = solveMuscleRedundancy(time,Misc)
 % -----------------------------------------------------------------------%
 % INPUTS:
 %           time: time window


### PR DESCRIPTION
1. BoolParamOpt
Converted BoolParamOpt to a Misc field, Misc.BoolParamOpt to avoid users having to edit the source code to change this. For most of us just running genericMRS this should be false, but it is set to true in the original code.

2. Save initial SO solution
Save initial SO solution before commencing genericMRS, and overwrite later if MRS solves successfully. Currently, if IPOPT fails (e.g. infeasible problem), an exception is thrown and the script terminates without saving the workspace. The SO solution is useful for troubleshooting failed trials.

3. I had added try/catch blocks around the genericMRS and plot states calls to manage failed trials, but commented these out as I felt these were better handled by users' own scripts that call MRS. Left the commented code in.